### PR TITLE
Add name to memory check job for status check

### DIFF
--- a/.github/workflows/c-make.yml
+++ b/.github/workflows/c-make.yml
@@ -21,6 +21,7 @@ jobs:
       run: make
 
   memory_test:
+    - name: Memory test
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request adds a name to the memory check job for status check. This will make it easier to identify the job in the workflow.