### PR TITLE
Add workflow_dispatch trigger to C Make workflow

### DIFF
--- a/.github/workflows/c-make.yml
+++ b/.github/workflows/c-make.yml
@@ -3,6 +3,7 @@ name: Configure and make
 on:
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This pull request adds a workflow_dispatch trigger to the C Make workflow, allowing manual triggering of the workflow in addition to the existing pull_request trigger. This provides more flexibility and control over when the workflow is executed.